### PR TITLE
fix ARM compile error

### DIFF
--- a/lib/capnp_c.h
+++ b/lib/capnp_c.h
@@ -115,7 +115,11 @@ struct capn_segment {
 	char *data;
 	size_t len, cap;
 	void *user;
-};
+}
+#if defined(__GNUC__)
+__attribute__ ((aligned(64)))
+#endif
+;
 
 enum CAPN_TYPE {
 	CAPN_NULL = 0,


### PR DESCRIPTION
This fixes `make` on ARMv7 platform. Needs testing to verify it doesn't break other platforms.
```
/usr/bin/make  all-recursive
make[1]: Entering directory '/tmp/c-capnproto'
make[2]: Entering directory '/tmp/c-capnproto'
  CC       lib/capn-malloc.lo
  CC       lib/capn-stream.lo
  CC       lib/capn.lo
  CC       compiler/capnpc-c.o
compiler/capnpc-c.c: In function 'main':
compiler/capnpc-c.c:1362:18: warning: format '%lu' expects argument of type 'long unsigned int', but argument 3 has type 'size_t {aka unsigned int}' [-Wformat=]
    fprintf(srcf, "static const uint8_t capn_buf[%lu] = {", g_valseg.len-8);
                  ^
compiler/capnpc-c.c:1372:18: warning: format '%lu' expects argument of type 'long unsigned int', but argument 3 has type 'size_t {aka unsigned int}' [-Wformat=]
    fprintf(srcf, "static const struct capn_segment capn_seg = {{0},0,0,0,(char*)&capn_buf[0],%lu,%lu};\n",
                  ^
compiler/capnpc-c.c:1372:18: warning: format '%lu' expects argument of type 'long unsigned int', but argument 4 has type 'size_t {aka unsigned int}' [-Wformat=]
lib/capn-malloc.c:24:36: error: negative width in bit-field 'foo'
  unsigned int foo : (sizeof(struct capn_segment)&7) ? -1 : 1;
                                    ^
Makefile:903: recipe for target 'lib/capn-malloc.lo' failed
make[2]: *** [lib/capn-malloc.lo] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: Leaving directory '/tmp/c-capnproto'
Makefile:1084: recipe for target 'all-recursive' failed
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory '/tmp/c-capnproto'
Makefile:668: recipe for target 'all' failed
make: *** [all] Error 2
```